### PR TITLE
Unlocked elasticsearch/elasticsearch version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 
     "require": {
         "php": ">=5.6.6",
-        "elasticsearch/elasticsearch": "5.0.0",
+        "elasticsearch/elasticsearch": "^5.0",
         "illuminate/pagination": "*",
         "illuminate/support": "*"
     },


### PR DESCRIPTION
... so that the package supported versions of elasticsearch/elasticsearch higher than 5.0.0.

I have a conflict with https://github.com/ErickTamayo/laravel-scout-elastic which uses higher version.