### PR TITLE
Added compatibility with Elasticsearch-php handler

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -58,6 +58,10 @@ class Connection
 
         $clientBuilder = ClientBuilder::create();
 
+        if (!empty($config['handler'])) {
+            $clientBuilder->setHandler($config['handler']);
+        }
+        
         $clientBuilder->setHosts($config["servers"]);
 
         $query = new Query($clientBuilder->build());
@@ -91,12 +95,17 @@ class Connection
         // Create a new connection.
 
         if (array_key_exists($name, $this->config["connections"])) {
-
+            $config = $this->config["connections"][$name];
+            
             // Instantiate a new ClientBuilder
             $clientBuilder = ClientBuilder::create();
 
-            $clientBuilder->setHosts($this->config["connections"][$name]["servers"]);
-
+            $clientBuilder->setHosts($config["servers"]);
+            
+            if (!empty($config['handler'])) {
+                $clientBuilder->setHandler($config['handler']);
+            }
+            
             // Build the client object
             $connection = $clientBuilder->build();
 


### PR DESCRIPTION
Issues: https://github.com/basemkhirat/elasticsearch/issues/42
More details by problem: https://github.com/aws/aws-sdk-php/issues/848
Documentation: https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_configuration.html#_configure_the_http_handler

For connect to AWS, pleas use this package https://github.com/jeskew/amazon-es-php
And configure your connection by example (es.php):
```
    'connections' => [

        'default' => [

            'servers' => [

                [
                    "host" => env("ELASTIC_HOST", "127.0.0.1"),
                    "port" => env("ELASTIC_PORT", 9200),
                    'scheme' => 'http',
                ]

            ],

            'handler' => new \Aws\ElasticsearchService\ElasticsearchPhpHandler(env('AWS_REGION')),

            'index' => env('ELASTIC_INDEX', 'users')

        ]
    ],
```