### PR TITLE
Remove irrelevant parameter from Query->get()

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -788,15 +788,12 @@ class Query
 
     /**
      * Get the collection of results
-     * @param string $scroll_id
      * @return array|Collection
      */
-    public function get($scroll_id = NULL)
+    public function get()
     {
 
-        $scroll_id = NULL;
-
-        $result = $this->getResult($scroll_id);
+        $result = $this->getResult(NULL);
 
         return $this->getAll($result);
     }


### PR DESCRIPTION
`Query->get()` can take `$scroll_id` as an input parameter even though it is immediately overriden as `NULL`, which can cause misleading expectations as to the behavior of the method.