### PR TITLE
Allow sort values returned by sorted query to persist in Model

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -926,6 +926,7 @@ class Query
             $model->_type = $row["_type"];
             $model->_id = $row["_id"];
             $model->_score = $row["_score"];
+            $model->sort = $row["sort"];
 
             $new[] = $model;
         }
@@ -969,6 +970,7 @@ class Query
             $model->_type = $data[0]["_type"];
             $model->_id = $data[0]["_id"];
             $model->_score = $data[0]["_score"];
+            $model->sort = $data[0]["sort"];
 
             $new = $model;
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -363,13 +363,12 @@ class Query
 
     /**
      * Store sort values used for search_after field
-     * @param string $sortValue
-     * @param string $identifier
+     * @param array $sortValues
      * @return $this
      */
-    public function searchAfter($sortValue, $identifier)
+    public function searchAfter($sortValues)
     {
-        $this->sortValues = [$sortValue, $identifier];
+        $this->sortValues = $sortValues;
 
         return $this;
     }
@@ -740,6 +739,13 @@ class Query
 
         }
 
+        if ($this->getSortValues()) {
+            $body["search_after"] = $this->getSortValues();
+
+            // Elasticsearch requires `from` to be 0 or -1 if using `search_after`
+            $body['from'] = 0;
+        }
+
         $this->body = $body;
 
         return $body;
@@ -778,13 +784,6 @@ class Query
         $query["from"] = $this->getSkip();
 
         $query["size"] = $this->getTake();
-
-        if ($this->getSortValues()) {
-            $query["search_after"] = $this->getSortValues();
-
-            // Elasticsearch requires `from` to be 0 or -1 if using `search_after`
-            $query['from'] = 0;
-        }
 
         if (count($this->ignores)) {
             $query["client"] = ['ignore' => $this->ignores];

--- a/src/Query.php
+++ b/src/Query.php
@@ -132,6 +132,13 @@ class Query
     protected $skip = 0;
 
     /**
+     * Sort values that should be used for search_after field
+     * @url https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-search-after.html
+     * @var array sort value and identifier
+     */
+    protected $sortValues = [];
+
+    /**
      * The key that should be used when caching the query.
      * @var string
      */
@@ -352,6 +359,27 @@ class Query
         $this->sort[] = [$field => $direction];
 
         return $this;
+    }
+
+    /**
+     * Store sort values used for search_after field
+     * @param string $sortValue
+     * @param string $identifier
+     * @return $this
+     */
+    public function searchAfter($sortValue, $identifier)
+    {
+        $this->sortValues = [$sortValue, $identifier];
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getSortValues()
+    {
+        return $this->sortValues;
     }
 
     /**
@@ -750,6 +778,13 @@ class Query
         $query["from"] = $this->getSkip();
 
         $query["size"] = $this->getTake();
+
+        if ($this->getSortValues()) {
+            $query["search_after"] = $this->getSortValues();
+
+            // Elasticsearch requires `from` to be 0 or -1 if using `search_after`
+            $query['from'] = 0;
+        }
 
         if (count($this->ignores)) {
             $query["client"] = ['ignore' => $this->ignores];


### PR DESCRIPTION
The Elasticsearch `search_after` field receives the sort values to provide a cursor after that given sort value. Currently, the Query class in this model is not persisting that `sort` array that is being returned in the Elasticsearch row. This persists that sort value array as a property on the Model object, alongside `_id`, `_score`, and other similar properties.