### PR TITLE
[PHP7.2] Issue count() throws exception

### DIFF
--- a/src/ScoutEngine.php
+++ b/src/ScoutEngine.php
@@ -168,7 +168,7 @@ class ScoutEngine extends Engine
      */
     public function map($results, $model)
     {
-        if (count($results['hits']['total']) === 0) {
+        if ($results['hits']['total'] === 0) {
             return Collection::make();
         }
 


### PR DESCRIPTION
Hi there,

Thank you for taking the time to write this library.

In the ScoutEngine mapping method there is a check to see if the hit results is 0 (and if so, return an empty collection); however, this line uses count() on an integer. In previous versions of PHP this wouldn't work either, but didn't throw an exception. In PHP7.2 this will throw an exception as count() expects an object/array that implements countable. See [https://3v4l.org/5aSG2](https://3v4l.org/5aSG2) This patch simply removes the call to count() and compares the integer.

![image](https://user-images.githubusercontent.com/3619398/36492387-0539c776-16fb-11e8-95ee-8c4e5fa9d4e8.png)

Thanks!

Joe