### PR TITLE
Modified the connection instance to singleton mode

### DIFF
--- a/src/ElasticsearchServiceProvider.php
+++ b/src/ElasticsearchServiceProvider.php
@@ -106,7 +106,7 @@ class ElasticsearchServiceProvider extends ServiceProvider
             }
         }
 
-        $this->app->bind('es', function () {
+        $this->app->singleton('es', function () {
             return new Connection();
         });
     }


### PR DESCRIPTION
Hi, @basemkhirat 
I found that when the connection instance runs the program on the console, it creates a lot of connections, causing unnecessary wear and tear, so it is modified into a singleton mode. 