### PR TITLE
Retain aggregation data retrieved from Elasticsearch

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -950,6 +950,7 @@ class Query
             $new->timed_out = $result["timed_out"];
             $new->scroll_id = isset($result["_scroll_id"]) ? $result["_scroll_id"] : NULL;
             $new->shards = (object)$result["_shards"];
+            $new->aggregations = isset($result['aggregations']) ? (object) $result['aggregations'] : NULL;
 
             return $new;
 


### PR DESCRIPTION
Hello Basem Khirat,

Your package helped me out a great deal, thank you!
I like to use some extra data retrieved from Elasticsearch, some already included (but not all):

`\Basemkhirat\Elasticsearch\Query`

```php
            $new->total = $result["hits"]["total"];
            $new->max_score = $result["hits"]["max_score"];
            $new->took = $result["took"];
            $new->timed_out = $result["timed_out"];  // typical Elasticsearch data
            $new->scroll_id = isset($result["_scroll_id"]) ? $result["_scroll_id"] : NULL;  // typical Elasticsearch data
            $new->shards = (object)$result["_shards"];  // typical Elasticsearch data
```

I would like to add this data so I can use this in my application:

```php
            $new->aggregations = isset($result['aggregations']) ? (object) $result['aggregations'] : NULL;
```

Nothing further has to be changed in you package, but with this change aggregations can be retrieved as follows:

```php

$rules = [
    'query' => [
        // ...
    ],
    'aggs' => [
        // ...
    ],
];

$result = MyModel::body($rules)->paginate();
$result->getCollection()->aggregations;
```

